### PR TITLE
Update category in webhooks.html

### DIFF
--- a/nodes/webhooks.html
+++ b/nodes/webhooks.html
@@ -45,7 +45,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('voice webhook',{
-        category: 'input',
+        category: 'nexmo',
         color: "#2d966f",
         defaults: {
             name: {value:""},
@@ -79,7 +79,7 @@
     });
 
     RED.nodes.registerType('return ncco',{
-        category: 'output',
+        category: 'nexmo',
         color: "#2d966f",
         defaults: {
             name: {value:""},

--- a/nodes/webhooks.html
+++ b/nodes/webhooks.html
@@ -45,7 +45,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('voice webhook',{
-        category: 'nexmo',
+        category: 'network',
         color: "#2d966f",
         defaults: {
             name: {value:""},
@@ -79,7 +79,7 @@
     });
 
     RED.nodes.registerType('return ncco',{
-        category: 'nexmo',
+        category: 'network',
         color: "#2d966f",
         defaults: {
             name: {value:""},


### PR DESCRIPTION
Updated the category of `voice webhook` and `return ncco`, in case you wanted to go that way.
They now appear under nexmo, instead of the previous input and output - that the default palette no longer has.