### PR TITLE
support node-red v1 async send api

### DIFF
--- a/nodes/insight.js
+++ b/nodes/insight.js
@@ -11,7 +11,8 @@ module.exports = function (RED) {
     this.ni_type = config.ni_type;
     var node = this;
     
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       var data = dataobject(this.context(), msg)
       this.number = mustache.render(config.number, data);
@@ -25,10 +26,14 @@ module.exports = function (RED) {
       nexmo.numberInsight.get({level: this.ni_type, number: this.number, callback: this.url}, (error, response) => {
         if(error) {
           console.error(error);
+          done(error);
         }
         else {
           msg.payload=response;
-          node.send(msg) 
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       });
     });  

--- a/nodes/ncco.js
+++ b/nodes/ncco.js
@@ -10,7 +10,8 @@ module.exports = function (RED) {
     this.loop = config.loop;
     this.level = config.level;
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var data = dataobject(this.context(), msg);
       this.text = mustache.render(config.text, data);
       this.voicename = mustache.render(config.voicename, data);
@@ -29,7 +30,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });  
   }
   function stream(config){
@@ -38,7 +42,8 @@ module.exports = function (RED) {
     this.loop = config.loop;
     this.level = config.level;
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var data = dataobject(this.context(), msg);
       this.streamurl = mustache.render(config.streamurl, data);
       if ( 'ncco' in msg){
@@ -55,7 +60,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });  
   }
   function input(config){
@@ -65,7 +73,8 @@ module.exports = function (RED) {
     this.submitonhash = config.submitonhash;
     this.eventmethod = config.eventmethod;  
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var data = dataobject(this.context(), msg);
       this.eventurl = mustache.render(config.eventurl, data);;
       if ( 'ncco' in msg){
@@ -85,7 +94,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });
   }
   
@@ -100,7 +112,8 @@ module.exports = function (RED) {
     this.endonkey = config.endonkey;  
     this.beepstart = config.beepstart;  
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var data = dataobject(this.context(), msg);
       this.eventurl = mustache.render(config.eventurl, data);
       if ( 'ncco' in msg){
@@ -124,7 +137,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });
   }
 
@@ -136,7 +152,8 @@ module.exports = function (RED) {
     this.endonexit = config.endonexit;
     this.startonenter = config.startonenter;
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       console.log(config);
       var data = dataobject(this.context(), msg);
       this.name = mustache.render(config.name, data);
@@ -169,7 +186,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });
   }
   
@@ -184,7 +204,8 @@ module.exports = function (RED) {
     this.endpoint = config.endpoint;
     this.contenttype = config.contenttype;
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var data = dataobject(this.context(), msg);
       this.to = mustache.render(config.to, data);
       this.wsuri = mustache.render(config.wsuri, data);
@@ -244,7 +265,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });
   }
 
@@ -253,7 +277,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     this.eventmethod = config.eventmethod;  
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var data = dataobject(this.context(), msg);
       this.payload = mustache.render(config.payload, data);
       this.eventurl = mustache.render(config.eventurl, data);
@@ -270,7 +295,10 @@ module.exports = function (RED) {
       clean(ncco);
       resp.push(ncco);
       msg.ncco = resp;
-      node.send(msg);
+      send(msg);
+      if(done) {
+        done();
+      }
     });
   }
   

--- a/nodes/sms_rest.js
+++ b/nodes/sms_rest.js
@@ -12,7 +12,8 @@ module.exports = function (RED) {
     this.unicode = config.unicode;
     var node = this;
     
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       var data = dataobject(this.context(), msg)
       this.to = mustache.render(config.to, data);
@@ -30,10 +31,15 @@ module.exports = function (RED) {
         opts.type = "text";
       }
       nexmo.message.sendSms(this.fr, this.to, this.text, opts, function(err, response){
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       })
     });  

--- a/nodes/vapi_rest.js
+++ b/nodes/vapi_rest.js
@@ -13,7 +13,8 @@ module.exports = function (RED) {
     this.machinedetection = config.machinedetection
     this.contenttype = config.contenttype
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       var data = dataobject(this.context(), msg);
       this.to = mustache.render(config.to, data);
@@ -80,10 +81,15 @@ module.exports = function (RED) {
       }
       clean(request);
       nexmo.calls.create(request, (err, response) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       });  
     });  
@@ -93,7 +99,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     this.creds = RED.nodes.getNode(config.creds);
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       this.filename = mustache.render(config.filename, dataobject(this.context(), msg));
       if (this.filename){
@@ -109,10 +116,14 @@ module.exports = function (RED) {
       nexmo.files.get(msg.payload.recording_url, (error, data) => {
             if (error) {
               console.log(error, null);
+              done(error);
             } else {
               console.log(data.length);
               msg.payload = data;
-              node.send(msg);
+              send(msg);
+              if(done) {
+                done();
+              }
             }
       });
       
@@ -124,7 +135,8 @@ module.exports = function (RED) {
     this.creds = RED.nodes.getNode(config.creds);
     this.state = config.state;
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       this.calluuid = mustache.render(config.calluuid, dataobject(this.context(), msg));
       const nexmo = new Nexmo({
@@ -136,18 +148,28 @@ module.exports = function (RED) {
       );
     if (this.state == "on"){
       nexmo.calls.update(this.calluuid, { action: 'earmuff' }, (err, res) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(response)  
+          send(response);
+          if(done) {
+            done();
+          }
         }
       });
     } else {
       nexmo.calls.update(this.calluuid, { action: 'unearmuff' }, (err, res) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       });
     }
@@ -160,7 +182,8 @@ module.exports = function (RED) {
     this.creds = RED.nodes.getNode(config.creds);
     this.state = config.state;
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       this.calluuid = mustache.render(config.calluuid, dataobject(this.context(), msg));
       const nexmo = new Nexmo({
@@ -172,18 +195,28 @@ module.exports = function (RED) {
       );
     if (this.state == "on"){
       nexmo.calls.update(this.calluuid, { action: 'mute' }, (err, res) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(response)  
+          send(response);
+          if(done) {
+            done();
+          }
         }
       });
     } else {
       nexmo.calls.update(this.calluuid, { action: 'unmute' }, (err, res) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       });
     }
@@ -195,7 +228,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     this.creds = RED.nodes.getNode(config.creds);
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       this.calluuid = mustache.render(config.calluuid, dataobject(this.context(), msg));
       const nexmo = new Nexmo({
@@ -206,10 +240,15 @@ module.exports = function (RED) {
         }, {debug: debug, appendToUserAgent: "nexmo-nodered/"+version}
       );
       nexmo.calls.update(this.calluuid, { action: 'hangup' }, (err, response) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       });
     
@@ -220,7 +259,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     this.creds = RED.nodes.getNode(config.creds);
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       var data = dataobject(this.context(), msg);
       this.calluuid = mustache.render(config.calluuid, data);
@@ -233,10 +273,15 @@ module.exports = function (RED) {
         }, {debug: debug, appendToUserAgent: "nexmo-nodered/"+version}
       );
       nexmo.calls.update(this.calluuid, {action: 'transfer', destination: {"type": "ncco", "url": [this.url]}}, (err, response) => {
-        if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
       });
     
@@ -253,7 +298,8 @@ module.exports = function (RED) {
     this.loop = config.loop
     this.level = config.level
     var node = this;
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       var data = dataobject(this.context(), msg);
       this.calluuid = mustache.render(config.calluuid, data);
@@ -267,18 +313,28 @@ module.exports = function (RED) {
       );
       if (this.action == 'on'){
         nexmo.calls.stream.start(this.calluuid, { stream_url: [this.url], loop: this.loop, level: this.level},  (err, response) => {
-          if(err) { console.error(err); }
-          else {
+          if(err) {
+            console.error(err);
+            done(err);
+          } else {
             msg.payload=response;
-            node.send(response)  
+            send(response);
+            if(done) {
+              done();
+            }
           }
         });
       } else {
         nexmo.calls.stream.stop(this.calluuid,  (err, response) => {
-          if(err) { console.error(err); }
-          else {
+          if(err) {
+            console.error(err);
+            done(err);
+          } else {
             msg.payload=response;
-            node.send(msg)  
+            send(msg);
+            if(done) {
+              done();
+            }
           }
         });
       }
@@ -294,7 +350,8 @@ module.exports = function (RED) {
    this.level = config.level;
    this.voicename = config.voicename;
    var node = this;
-   node.on('input', function (msg) {
+   node.on('input', function (msg, send, done) {
+     send = send || function() { node.send.apply(node,arguments) };
      var debug = (this.context().global.get('nexmoDebug') | false);
      var data = dataobject(this.context(), msg);
      this.calluuid = mustache.render(config.calluuid, data);
@@ -309,18 +366,28 @@ module.exports = function (RED) {
      );
      if (this.action == 'on'){
        nexmo.calls.talk.start(this.calluuid, { text: this.text, voice_name: this.voicename, loop: this.loop, level: this.level },  (err, response) => {
-         if(err) { console.error(err); }
-         else {
+         if(err) {
+           console.error(err);
+           done(err);
+         } else {
            msg.payload=response;
-           node.send(response)  
+           send(response);
+           if(done) {
+            done();
+          }
          }
        });
      } else {
        nexmo.calls.talk.stop(this.calluuid,  (err, res) => {
-         if(err) { console.error(err); }
-         else {
+         if(err) {
+           console.error(err);
+           done(err);
+         } else {
            msg.payload=response;
-           node.send(msg)  
+           send(msg);
+           if(done) {
+            done();
+          }
          }
        });
      }
@@ -331,7 +398,8 @@ function playdtmf(config){
   RED.nodes.createNode(this, config);
   this.creds = RED.nodes.getNode(config.creds);
   var node = this;
-  node.on('input', function (msg) {
+  node.on('input', function (msg, send, done) {
+    send = send || function() { node.send.apply(node,arguments) };
     var debug = (this.context().global.get('nexmoDebug') | false);
     var data = dataobject(this.context(), msg);
     this.calluuid = mustache.render(config.calluuid, data);
@@ -345,10 +413,14 @@ function playdtmf(config){
     );
     nexmo.calls.dtmf.send(this.calluuid, { digits: this.digits }, (err, response) => {
        if(err) { 
-        console.error(err); 
+        console.error(err);
+        done(err);
        } else {
         msg.payload=response;
-        node.send(msg)  
+        send(msg);
+         if(done) {
+           done();
+         }
        }
     });
   });  
@@ -365,7 +437,7 @@ function playdtmf(config){
   RED.nodes.registerType("createcall",createCall);
   RED.nodes.registerType("earmuff",earmuff);    
   RED.nodes.registerType("getrecording",GetRecording);
-  RED.nodes.registerType("mute",mute);    
+  RED.nodes.registerType("mute",mute);
   RED.nodes.registerType("hangup",hangup);    
   RED.nodes.registerType("transfer",transfer);
   RED.nodes.registerType("playaudio",playaudio);

--- a/nodes/verify.js
+++ b/nodes/verify.js
@@ -9,7 +9,8 @@ module.exports = function (RED) {
     this.creds = RED.nodes.getNode(config.creds);
     var node = this;
     
-    node.on('input', function (msg) {
+    node.on('input', function (msg, send, done) {
+      send = send || function() { node.send.apply(node,arguments) };
       var debug = (this.context().global.get('nexmoDebug') | false);
       var data = dataobject(this.context(), msg)
       this.to = mustache.render(config.to, data);
@@ -20,12 +21,17 @@ module.exports = function (RED) {
       }, {debug: debug, appendToUserAgent: "nexmo-nodered/3.0.0"}
       );
       nexmo.verify.request({number: this.to, brand: this.brand}, function(err, response) {
-          if(err) { console.error(err); }
-        else {
+        if(err) {
+          console.error(err);
+          done(err);
+        } else {
           msg.payload=response;
-          node.send(msg)  
+          send(msg);
+          if(done) {
+            done();
+          }
         }
-      })
+      });
     });  
   }
   
@@ -34,7 +40,8 @@ module.exports = function (RED) {
    this.creds = RED.nodes.getNode(config.creds);
    var node = this;
    
-   node.on('input', function (msg) {
+   node.on('input', function (msg, send, done) {
+     send = send || function() { node.send.apply(node,arguments) };
      var debug = (this.context().global.get('nexmoDebug') | false);
      var data = dataobject(this.context(), msg)
      this.verify_id = mustache.render(config.verify_id, data);
@@ -45,10 +52,15 @@ module.exports = function (RED) {
      }, {debug: debug, appendToUserAgent: "nexmo-nodered/"+version}
      );
      nexmo.verify.check({request_id: this.verify_id, code: this.code}, function(err, response) {
-         if(err) { console.error(err); }
-       else {
+       if(err) {
+         console.error(err);
+         done(err);
+       } else {
          msg.payload=response;
-         node.send(msg)  
+         send(msg);
+         if(done) {
+           done();
+         }
        }
      })
    });  
@@ -59,7 +71,8 @@ module.exports = function (RED) {
   this.creds = RED.nodes.getNode(config.creds);
   var node = this;
   
-  node.on('input', function (msg) {
+  node.on('input', function (msg, send, done) {
+    send = send || function() { node.send.apply(node,arguments) };
     var debug = (this.context().global.get('nexmoDebug') | false);
     this.verify_id = mustache.render(config.verify_id, dataobject(this.context(), msg));
     const nexmo = new Nexmo({
@@ -68,10 +81,15 @@ module.exports = function (RED) {
     }, {debug: debug, appendToUserAgent: "nexmo-nodered/"+version}
     );
     nexmo.verify.control({request_id: this.verify_id, cmd: 'cancel'}, function(err, response) {
-        if(err) { console.error(err); }
-      else {
+      if(err) {
+        console.error(err);
+        done(err);
+      } else {
         msg.payload=response;
-        node.send(msg)  
+        send(msg);
+        if(done) {
+          done();
+        }
       }
     })
   });  
@@ -82,7 +100,8 @@ module.exports = function (RED) {
   this.creds = RED.nodes.getNode(config.creds);
   var node = this;
   
-  node.on('input', function (msg) {
+  node.on('input', function (msg, send, done) {
+    send = send || function() { node.send.apply(node,arguments) };
     var debug = (this.context().global.get('nexmoDebug') | false);
     this.verify_id = mustache.render(config.verify_id, dataobject(this.context(), msg));
     const nexmo = new Nexmo({
@@ -91,10 +110,15 @@ module.exports = function (RED) {
     }, {debug: debug, appendToUserAgent: "nexmo-nodered/"+version}
     );
     nexmo.verify.control({request_id: this.verify_id, cmd: 'trigger_next_event'}, function(err, response) {
-        if(err) { console.error(err); }
-      else {
+      if(err) {
+        console.error(err);
+        done(err);
+      } else {
         msg.payload=response;
-        node.send(msg)  
+        send(msg);
+        if(done) {
+          done();
+        }
       }
     })
   });  
@@ -105,7 +129,8 @@ function searchverify(config){
   this.creds = RED.nodes.getNode(config.creds);
   var node = this;
 
-  node.on('input', function(msg) {
+  node.on('input', function(msg, send, done) {
+    send = send || function() { node.send.apply(node,arguments) };
     var debug = (this.context().global.get('nexmoDebug') | false);
     this.verify_id = mustache.render(config.verify_id, dataobject(this.context(), msg));
     const nexmo = new Nexmo({
@@ -116,9 +141,13 @@ function searchverify(config){
     nexmo.verify.search(this.verify_id, function(err, response) {
       if (err) {
         console.error(err);
+        done(err);
       } else {
         msg.payload = response;
-        node.send(msg)
+        send(msg);
+        if(done) {
+          done();
+        }
       }
     });
     

--- a/nodes/webhooks.js
+++ b/nodes/webhooks.js
@@ -276,7 +276,7 @@ module.exports = function(RED) {
         var node = this;
         this.headers = {};
         this.statusCode=200;
-        this.on("input",function(msg) {
+        this.on("input",function(msg, send, done) {
             if (msg.res) {
                 var headers = RED.util.cloneMessage(node.headers);
                 if (msg.headers) {
@@ -302,6 +302,7 @@ module.exports = function(RED) {
                  var statusCode = node.statusCode || msg.statusCode || 200;
                 if (typeof msg.ncco == "object" && !Buffer.isBuffer(msg.ncco)) {
                     msg.res._res.status(statusCode).jsonp(msg.ncco);
+                    done();
                 } else {
                     if (msg.res._res.get('content-length') == null) {
                         var len;
@@ -316,6 +317,7 @@ module.exports = function(RED) {
                     }
 
                     msg.res._res.status(statusCode).send(msg.ncco);
+                    done();
                 }
             } else {
                 node.warn(RED._("httpin.errors.no-response"));


### PR DESCRIPTION
This PR changes the syntax of listening to incoming messages and sending outgoing messages to be asynchronous, as is the best-practice for Node-RED v1 nodes.
Backward compatibility is maintained as detailed here
https://nodered.org/blog/2019/09/20/node-done#backwards-compatibility

resolves #46 